### PR TITLE
Update for dnsv2 support. Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ foo:
     type: CNAME
     value: bar.octodns-test.com.
 
+oldns:
+  - ttl: 3600
+    type: NS
+    values:
+      - ns1.selectel.com.
+      - ns2.selectel.com.
+
 sshfp:
   - ttl: 3600
     type: SSHFP
@@ -179,13 +186,6 @@ txt:
     values: 
       - "bar_txt"
       - "foo_txt"
-
-oldns:
-  - ttl: 3600
-    type: NS
-    values:
-      - ns1.selectel.com.
-      - ns2.selectel.com.
 ```
 
 zones/octodns-test-alias.com.yaml

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An [octoDNS](https://github.com/octodns/octodns/) provider that targets [Selectel DNS](https://docs.selectel.com/cloud-services/dns-hosting/dns_hosting/).
 
-## Table of Contents
+## Contents
 
 * [Installation](#installation)
   * [Command line](#command-line)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For receive KEYSTONE_PROJECT_TOKEN read [here](#token-for-provider)
 Structure folders
 
 ```bash
+# e.g. .octodns
 ├── config.yaml
 └── zones
     ├── octodns-test-alias.com.yaml

--- a/README.md
+++ b/README.md
@@ -87,6 +87,107 @@ zones:
     - selectel_v2
 ```
 
+### Examples
+
+config.yaml
+
+```yaml
+---
+processors:
+  no-root-ns:
+    class: octodns.processor.filter.IgnoreRootNsFilter
+providers:
+  config:
+    class: octodns.provider.yaml.YamlProvider
+    directory: ./zones
+    default_ttl: 3600
+    enforce_order: True
+  selectel_v2:
+    class: octodns_selectel.SelectelProviderV2
+    token: env/KEYSTONE_PROJECT_TOKEN
+zones:
+  octodns-test.ru.:
+    sources:
+      - config
+    targets:
+      - selectel_v2
+  octodns-test-alias.ru.:
+    sources:
+      - config
+    targets:
+      - selectel_v2
+```
+
+zones/octodns-test-zone.com.yaml
+
+```yaml
+---
+'':
+  - ttl: 3600
+    type: A
+    values:
+      - 1.2.3.4
+      - 1.2.3.5
+  - ttl: 3600
+    type: AAAA
+    values: 
+      - 6dc1:b9af:74ca:84e9:6c7c:5c0f:c292:9188
+      - 5051:e345:9038:052c:00db:eb98:d871:8ae6
+  - ttl: 3600
+    type: MX
+    value:
+      exchange: mail1.octodns-test.ru.
+      preference: 10
+  - ttl: 3600
+    type: TXT
+    values: 
+      - "bar"
+      - "foo"
+
+_sip._tcp:
+  - ttl: 3600
+    type: SRV
+    values:
+    - port: 5060
+      priority: 10
+      target: phone1.example.com.
+      weight: 60
+    - port: 5030
+      priority: 20
+      target: phone2.example.com.
+      weight: 0     
+
+foo:
+  - ttl: 3600
+    type: CNAME
+    value: bar.octodns-test.ru.
+
+sshfp2:
+  - ttl: 3600
+    type: SSHFP
+    values:
+    - algorithm: 1
+      fingerprint: "4158f281921260b0205508121c6f5cee879e15f22bdbc319ef2ae9fd308db3be"
+      fingerprint_type: 2
+    - algorithm: 4
+      fingerprint: "123456789abcdef67890123456789abcdef67890123456789abcdef123456789"
+      fingerprint_type: 2
+
+txt2:
+  - ttl: 3600
+    type: TXT
+    values: 
+      - "bar_txt"
+      - "foo_txt"
+
+v12:
+  - ttl: 3600
+    type: NS
+    values:
+      - ns1.selectel.ru.
+      - ns2.selectel.ru.
+```
+
 ### Support Information
 
 #### Records

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Selectel DNS provider for octoDNS
 
-An [octoDNS](https://github.com/octodns/octodns/) provider that targets [Selectel DNS](https://selectel.ru/en/services/additional/dns/).
+An [octoDNS](https://github.com/octodns/octodns/) provider that targets [Selectel DNS](https://docs.selectel.com/cloud-services/dns-hosting/dns_hosting/).
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -32,22 +32,80 @@ octodns-selectel==0.0.3
 
 ### Configuration
 
+| :memo:        | Use SelectelProviderV2  |
+|---------------|:------------------------|
+
+#### Selectel Provider V1
+
 ```yaml
 providers:
   selectel:
-    class: octodns_selectel.SelectelProvider
+    class: octodns_selectel.SelectelProviderV1
     token: env/SELECTEL_TOKEN
+```
+
+#### Selectel Provider V2
+
+```yaml
+providers:
+  selectel:
+    class: octodns_selectel.SelectelProviderV2
+    token: env/KEYSTONE_PROJECT_TOKEN
+```
+
+#### Token for Provider V1
+
+Use Selectel Token.
+More information about Selectel Token read [here](https://developers.selectel.com/docs/control-panel/authorization/#selectel-token-api-key).
+
+#### Token for Provider V2
+
+Use Keystone Project Token.
+More information about Keystone Project Token read [here](https://developers.selectel.com/docs/control-panel/authorization/#project-token).
+
+### Migrating from DNS V1 to DNS V2
+
+```yaml
+---
+processors:
+  no-root-ns:
+    class: octodns.processor.filter.IgnoreRootNsFilter
+providers:
+  selectel_v1:
+    class: octodns_selectel.SelectelProviderV1
+    token: env/SELECTEL_TOKEN
+  selectel_v2:
+    class: octodns_selectel.SelectelProviderV2
+    token: env/KEYSTONE_PROJECT_TOKEN
+zones: 
+  "*":
+    sources:
+    - selectel_v1
+    processors:
+    - no-root-ns
+    targets:
+    - selectel_v2
 ```
 
 ### Support Information
 
 #### Records
 
-SelectelProvider supports A, AAAA, ALIAS, CNAME, MX, NS, SRV, SSHFP and TXT
+SelectelProviderV1 and SelectelProviderV2 supports:
+
+1. A;
+2. AAAA;
+3. ALIAS;
+4. CNAME;
+5. MX;
+6. NS;
+7. SRV;
+8. SSHFP
+9. TXT
 
 #### Dynamic
 
-SelectelProvider does not support dynamic records.
+SelectelProviderV1 and SelectelProviderV2 does not support dynamic records.
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ providers:
     token: env/KEYSTONE_PROJECT_TOKEN
 ```
 Set **KEYSTONE_PROJECT_TOKEN** environmental variable or write value directly in config without `env/` prefix.  
-How to obtain required token you can read [here](#token-for-selectelprovider)
+How to obtain required token you can read [here](https://developers.selectel.com/docs/control-panel/authorization/#project-token)
 ## Quickstart
 To get more details on configuration and capabilities check [octodns repository](https://github.com/octodns/octodns)
 #### 1. Organize your configs.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,36 @@
 
 An [octoDNS](https://github.com/octodns/octodns/) provider that targets [Selectel DNS](https://docs.selectel.com/cloud-services/dns-hosting/dns_hosting/).
 
-### Installation
+## Table of Contents
 
-#### Command line
+* [Installation](#installation)
+  * [Command line](#command-line)
+  * [requirements.txt/setup.py](#requirements-or-setup)
+* [Configuration](#configuration)
+  * [Selectel Provider](#selectel-provider)
+* [Examples](#configuration)
+  * [Create zone and added records](#create-zone-and-added-records)
+  * [Migrating from DNS V1 to DNS V2](#migrating-from-dns-v1-to-dns-v2)
+  * [Token for SelectelProviderLegacy](#token-for-selectelproviderlegacy)
+  * [Token for SelectelProvider](#token-for-selectelprovider)
+* [Support Information](#support-information)
+  * [Records](#records)
+  * [Dynamic](#dynamic)
+* [Development](#development)
+
+## Installation
+
+### Command line
 
 ```bash
 pip install octodns-selectel
 ```
 
-#### requirements.txt/setup.py
+### requirements.txt/setup.py {#requirements-or-setup}
 
 Pinning specific versions is recommended to avoid unplanned upgrades.
 
-##### Versions
+#### Versions
 
 ```
 # Start with the latest versions and don't just copy what's here
@@ -22,9 +39,9 @@ octodns==1.4.0
 octodns-selectel==1.0.0
 ```
 
-### Configuration
+## Configuration
 
-#### Selectel Provider
+### Selectel Provider
 
 ```yaml
 providers:
@@ -33,9 +50,11 @@ providers:
     token: env/KEYSTONE_PROJECT_TOKEN
 ```
 
-For receive KEYSTONE_PROJECT_TOKEN read [here](#token-for-provider)
+For receive KEYSTONE_PROJECT_TOKEN read [here](#token-for-selectelprovider)
 
-### Examples
+## Examples
+
+### Create zone and added records
 
 Structure folders
 
@@ -153,7 +172,7 @@ Use command:
 $octodns-sync --config-file=./config.yaml
 ```
 
-#### Migrating from DNS V1 to DNS V2
+### Migrating from DNS V1 to DNS V2
 
 ```yaml
 # ./config-migrate.yaml
@@ -185,26 +204,26 @@ Use command:
 $octodns-sync --config-file=./config-migrate.yaml
 ```
 
-#### Token for ProviderLegacy
+### Token for SelectelProviderLegacy
 
 Use Selectel Token.
 More information about Selectel Token read [here](https://developers.selectel.com/docs/control-panel/authorization/#selectel-token-api-key).
 
-#### Token for Provider
+### Token for SelectelProvider
 
 Use Keystone Project Token.
 More information about Keystone Project Token read [here](https://developers.selectel.com/docs/control-panel/authorization/#project-token).
 
-### Support Information
+## Support Information
 
-#### Records
+### Records
 
 SelectelProvider supports A, AAAA, ALIAS, CNAME, MX, NS, SRV, SSHFP and TXT
 
-#### Dynamic
+### Dynamic
 
 SelectelProvider does not support dynamic records.
 
-### Development
+## Development
 
 See the [/script/](/script/) directory for some tools to help with the development process. They generally follow the [Script to rule them all](https://github.com/github/scripts-to-rule-them-all) pattern. Most useful is `./script/bootstrap` which will create a venv and install both the runtime and development related requirements. It will also hook up a pre-commit hook that covers most of what's run by CI.

--- a/README.md
+++ b/README.md
@@ -106,19 +106,19 @@ providers:
     class: octodns_selectel.SelectelProviderV2
     token: env/KEYSTONE_PROJECT_TOKEN
 zones:
-  octodns-test.ru.:
+  octodns-test.com.:
     sources:
       - config
     targets:
       - selectel_v2
-  octodns-test-alias.ru.:
+  octodns-test-alias.com.:
     sources:
       - config
     targets:
       - selectel_v2
 ```
 
-zones/octodns-test-zone.com.yaml
+zones/octodns-test.com.yaml
 
 ```yaml
 ---
@@ -136,7 +136,7 @@ zones/octodns-test-zone.com.yaml
   - ttl: 3600
     type: MX
     value:
-      exchange: mail1.octodns-test.ru.
+      exchange: mail1.octodns-test.com.
       preference: 10
   - ttl: 3600
     type: TXT
@@ -160,9 +160,9 @@ _sip._tcp:
 foo:
   - ttl: 3600
     type: CNAME
-    value: bar.octodns-test.ru.
+    value: bar.octodns-test.com.
 
-sshfp2:
+sshfp:
   - ttl: 3600
     type: SSHFP
     values:
@@ -173,19 +173,29 @@ sshfp2:
       fingerprint: "123456789abcdef67890123456789abcdef67890123456789abcdef123456789"
       fingerprint_type: 2
 
-txt2:
+txt:
   - ttl: 3600
     type: TXT
     values: 
       - "bar_txt"
       - "foo_txt"
 
-v12:
+oldns:
   - ttl: 3600
     type: NS
     values:
-      - ns1.selectel.ru.
-      - ns2.selectel.ru.
+      - ns1.selectel.com.
+      - ns2.selectel.com.
+```
+
+zones/octodns-test-alias.com.yaml
+
+```yaml
+---
+'':
+  - ttl: 3600
+    type: ALIAS
+    value: octodns-test.com.
 ```
 
 ### Support Information

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ txt:
 Use command:
 
 ```bash
-$octodns-sync --config-file=config.yaml
+$octodns-sync --config-file=./config.yaml
 ```
 
 #### Migrating from DNS V1 to DNS V2
@@ -182,7 +182,7 @@ zones:
 Use command:
 
 ```bash
-$octodns-sync --config-file=config-migrate.yaml
+$octodns-sync --config-file=./config-migrate.yaml
 ```
 
 #### Token for ProviderLegacy


### PR DESCRIPTION
Не менял версию библиотеки для octodns-selectel, так как не знаю на какой sha потом изменить исходный sha.

Добавил примеры конфигурации. 
Сделал пометку, что лучше использовать V2.

Сделал ссылки на информацию о Selectel Token и Keystone Project Token. Ссылки ведут на английскую версию (.com).

Добавил пример миграции с в1 на в2.

Добавил примеры работы с разными записями (везде оставил во множественном числе). Так же примеры сделал на доменах .com

Поправил битую ссылку на Selectel DNS.