### PR TITLE
Fix space in value of CAA record

### DIFF
--- a/octodns_selectel/v2/mappings.py
+++ b/octodns_selectel/v2/mappings.py
@@ -98,7 +98,7 @@ def to_octodns_record_data(rrset):
         ]
     elif rrset_type == "CAA":
         for record in rrset["records"]:
-            flag, tag, value = record["content"].split(' ', 2)
+            flag, tag, value = record["content"].split(" ", 2)
             record_values.append(
                 {'flags': flag, 'tag': tag, 'value': value.strip('"')}
             )

--- a/octodns_selectel/v2/mappings.py
+++ b/octodns_selectel/v2/mappings.py
@@ -99,7 +99,9 @@ def to_octodns_record_data(rrset):
     elif rrset_type == "CAA":
         for record in rrset["records"]:
             flag, tag, value = record["content"].split(' ', 2)
-            record_values.append({'flags': flag, 'tag': tag, 'value': value})
+            record_values.append(
+                {'flags': flag, 'tag': tag, 'value': value.strip('"')}
+            )
     elif rrset_type == "MX":
         for record in rrset["records"]:
             preference, exchange = record["content"].split(" ")

--- a/octodns_selectel/v2/mappings.py
+++ b/octodns_selectel/v2/mappings.py
@@ -98,10 +98,8 @@ def to_octodns_record_data(rrset):
         ]
     elif rrset_type == "CAA":
         for record in rrset["records"]:
-            flag, tag, value = record["content"].split(" ")
-            record_values.append(
-                {'flags': flag, 'tag': tag, 'value': value.strip("\"")}
-            )
+            flag, tag, value = record["content"].split(' ', 2)
+            record_values.append({'flags': flag, 'tag': tag, 'value': value})
     elif rrset_type == "MX":
         for record in rrset["records"]:
             preference, exchange = record["content"].split(" ")

--- a/tests/v2/test_selectel_mappings.py
+++ b/tests/v2/test_selectel_mappings.py
@@ -685,22 +685,6 @@ class TestSelectelMappings(TestCase):
                     ],
                 ),
             ),
-            PairTest(
-                CaaRecord(
-                    self.zone,
-                    "",
-                    dict(type="CAA", ttl=self.ttl, values=caa_list_dict),
-                ),
-                dict(
-                    name=self.zone.name,
-                    ttl=self.ttl,
-                    type="CAA",
-                    records=[
-                        dict(content=caa_str_item)
-                        for caa_str_item in caa_list_str
-                    ],
-                ),
-            ),
         )
         self._assert_mapping_common(test_pairs)
         self._assert_mapping_caa(test_pairs)

--- a/tests/v2/test_selectel_mappings.py
+++ b/tests/v2/test_selectel_mappings.py
@@ -629,6 +629,11 @@ class TestSelectelMappings(TestCase):
             dict(
                 flags="0", tag="iodef", value="mailto:notification@example.com"
             ),
+            dict(
+                flags="0",
+                tag="issue",
+                value="otherca.com;accounturi=https://otherca.com/acct/123456",
+            ),
         ]
         caa_list_str = [
             self._caa_to_string(caa_dict_item)
@@ -656,6 +661,22 @@ class TestSelectelMappings(TestCase):
                 ),
                 dict(
                     name=f"caa.{self.zone.name}",
+                    ttl=self.ttl,
+                    type="CAA",
+                    records=[
+                        dict(content=caa_str_item)
+                        for caa_str_item in caa_list_str
+                    ],
+                ),
+            ),
+            PairTest(
+                CaaRecord(
+                    self.zone,
+                    "",
+                    dict(type="CAA", ttl=self.ttl, values=caa_list_dict),
+                ),
+                dict(
+                    name=self.zone.name,
                     ttl=self.ttl,
                     type="CAA",
                     records=[

--- a/tests/v2/test_selectel_mappings.py
+++ b/tests/v2/test_selectel_mappings.py
@@ -632,7 +632,7 @@ class TestSelectelMappings(TestCase):
             dict(
                 flags="0",
                 tag="issue",
-                value="otherca.com;accounturi=https://otherca.com/acct/123456",
+                value="otherca.com; accounturi=https://otherca.com/acct/123456",
             ),
         ]
         caa_list_str = [


### PR DESCRIPTION
I fixed work with CAA records which  includes spaces in its values.
Resolve this [issue](https://github.com/octodns/octodns-selectel/issues/55).

After merge this PR I will bump it.